### PR TITLE
chore: update Cloud2SQL version to 0.9.0

### DIFF
--- a/latestRelease.json
+++ b/latestRelease.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.8.3",
-  "link": "https://github.com/someengineering/cloud2sql/releases/tag/0.8.3"
+  "version": "0.9.0",
+  "link": "https://github.com/someengineering/cloud2sql/releases/tag/0.9.0"
 }


### PR DESCRIPTION
Updates Cloud2SQL version on cloud2sql.com to `0.9.0`.